### PR TITLE
Allow enemies to scale linearly

### DIFF
--- a/playtestv2.ipynb
+++ b/playtestv2.ipynb
@@ -70,7 +70,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "goon = Enemy(\"Goon\", 40, 40, 8, \"Attacks the front of your team for {attack} each turn\")\n",
+    "goon = Enemy(\n",
+    "    \"Goon\", \n",
+    "    40,\n",
+    "    40, \n",
+    "    8, \n",
+    "    \"Attacks the front of your team for {attack} each turn.\",\n",
+    ")\n",
     "\n",
     "testbed.combat([goon])"
    ]
@@ -112,10 +118,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "goon = Enemy(\"Goon\", 40, 20, 8, \"Attacks the front of your team for {attack} each turn\")\n",
-    "goblin = Enemy(\"Goblin\", 35, 0, 9, \"Attacks the back of your team for {attack} each turn\")\n",
+    "troll = Enemy(\n",
+    "    \"Troll\", \n",
+    "    35,\n",
+    "    35, \n",
+    "    4, \n",
+    "    \"Currently attacking the front of your team for {attack}. Scales by {scaling_factor} each turn.\",\n",
+    "    scaling_factor=1,\n",
+    ")\n",
+    "goblin = Enemy(\n",
+    "    \"Goblin\", \n",
+    "    25,\n",
+    "    25, \n",
+    "    5,\n",
+    "    \"Currently attacking the back of your team for {attack}. Scales by {scaling_factor} each turn.\",\n",
+    "    scaling_factor=2,\n",
+    ")\n",
     "\n",
-    "testbed.combat([goon, goblin])"
+    "testbed.combat([troll, goblin])"
    ]
   },
   {

--- a/signified/entity.py
+++ b/signified/entity.py
@@ -20,6 +20,8 @@ class Entity:
 class Enemy(Entity):
     attack: int
     attack_pattern_tmpl: str
+    # Optional scaling factor for the Enemy that gives linearly increasing attack.
+    scaling_factor: int = 0
 
 
 @dataclass

--- a/signified/testbed.py
+++ b/signified/testbed.py
@@ -64,7 +64,7 @@ class TestingInstance:
 
         enemy_tracker = {enemy.name: enemy for enemy in enemies}
 
-        available_actions = ["damage", "exit", "status"]
+        available_actions = ["damage", "exit", "status", "endturn"]
         print_combat_status(self.companion_roster, enemies)
         print("Starting combat.")
         print(f"Available actions: {available_actions}")
@@ -96,6 +96,11 @@ class TestingInstance:
             elif chosen_action == "exit":
                 break
             elif chosen_action == "status":
+                print_combat_status(self.companion_roster, enemies)
+            elif chosen_action == "endturn":
+                print("End of turn; scaling enemies")
+                for _, enemy in enemy_tracker.items():
+                    enemy.attack += enemy.scaling_factor
                 print_combat_status(self.companion_roster, enemies)
 
     def shop(self) -> None:

--- a/signified/utils.py
+++ b/signified/utils.py
@@ -42,7 +42,9 @@ def print_companion_roster(companion_roster: Dict[str, Companion]):
 
 def print_enemies(dudes: List[Enemy]) -> None:
     for dude in dudes:
-        attack_pattern = dude.attack_pattern_tmpl.format(attack=dude.attack)
+        attack_pattern = dude.attack_pattern_tmpl.format(
+            attack=dude.attack, scaling_factor=dude.scaling_factor
+        )
         print(
             f"{dude.name.ljust(15)} {dude.health}/{dude.max_health}💖 {attack_pattern}"
         )


### PR DESCRIPTION
This commit also changes the enemies in the second combat to have less health but also scale.
It needs verification in a playtest, but the idea is that you can get through it with a team of 3 companions and a team of 4 companions.